### PR TITLE
add support of btsync api v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,19 @@ BTSyncAPI.prototype.removeFolder = function (folderId, params, callback) {
   });
 };
 
+BTSyncAPI.prototype.generateSecret = function (params, callback) {
+  params = _.extend(params, {
+    token: this.token
+  }, false);
+
+  this.request.post({
+    json: true,
+    url: this.url + '/secret?' + querystring.stringify(params),
+  }, function(err, res, body) {
+    return callback(err, body);
+  });
+};
+
 // TODO: reuse this function to keep DRY in other calls
 // BTSyncAPI.prototype.call = function(action, params, callback) {
 //   if(!callback && typeof params === 'function') {

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ BTSyncAPI.prototype.addFolder = function (params, callback) {
     url: this.url + '/folders?' + querystring.stringify(params),
   }, function(err, res, body) {
     // try to reestablish connection only once
-    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+    if ((err || body === '\r\ninvalid request') && !hasRetried) {
       _this.getTokenAndCookie(function(err, token) {
         if(err) return callback(err); // we can not reconnect
 
@@ -140,7 +140,7 @@ BTSyncAPI.prototype.removeFolder = function (folderId, params, callback) {
     url: this.url + '/folders/' + folderId + '?' + querystring.stringify(params),
   }, function(err, res, body) {
     // try to reestablish connection only once
-    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+    if ((err || body === '\r\ninvalid request') && !hasRetried) {
       _this.getTokenAndCookie(function(err, token) {
         if(err) return callback(err); // we can not reconnect
 
@@ -168,7 +168,7 @@ BTSyncAPI.prototype.generateSecret = function (params, callback) {
     url: this.url + '/secret?' + querystring.stringify(params),
   }, function(err, res, body) {
     // try to reestablish connection only once
-    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+    if ((err || body === '\r\ninvalid request') && !hasRetried) {
       _this.getTokenAndCookie(function(err, token) {
         if (err) return callback(err); // we can not reconnect
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ var BTSyncAPI = function(options) {
   this.url = 'http://' + this.options.host + ':' + this.options.port + '/api/v2';
 
   client.getTokenAndCookie(function(err, token) {
-    if(err) return client.emit('error', error);
+    if(err) return client.emit('error', err);
 
     client.setToken(token);
     client.emit('ready');

--- a/index.js
+++ b/index.js
@@ -138,6 +138,19 @@ BTSyncAPI.prototype.generateSecret = function (params, callback) {
   });
 };
 
+BTSyncAPI.prototype.getEvents = function (params, callback) {
+  params = _.extend(params, {
+    token: this.token
+  }, false);
+
+  this.request.get({
+    json: true,
+    url: this.url + '/events?' + querystring.stringify(params),
+  }, function(err, res, body) {
+    return callback(err, body);
+  });
+};
+
 // TODO: reuse this function to keep DRY in other calls
 // BTSyncAPI.prototype.call = function(action, params, callback) {
 //   if(!callback && typeof params === 'function') {

--- a/index.js
+++ b/index.js
@@ -86,6 +86,34 @@ BTSyncAPI.prototype.getTokenAndCookie = function(callback) {
   });
 };
 
+BTSyncAPI.prototype.getFolders = function (callback) {
+  _this = this;
+  var hasRetried = false;
+
+  params = _.extend({}, {
+    token: this.token
+  }, false);
+
+  this.request.get({
+    json: true,
+    url: this.url + '/folders?' + querystring.stringify(params),
+  }, function(err, res, body) {
+    // try to reestablish connection only once
+    if ((err || body === '\r\ninvalid request') && !hasRetried) {
+      _this.getTokenAndCookie(function(err, token) {
+        if(err) return callback(err); // we can not reconnect
+
+        hasRetried = true;
+
+        _this.setToken(token);
+        _this.getAllFolders(callback);
+      });
+    } else {
+      return callback(err, body);
+    }
+  });
+};
+
 BTSyncAPI.prototype.addFolder = function (params, callback) {
   _this = this;
   var hasRetried = false;

--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ BTSyncAPI.prototype.getTokenAndCookie = function(callback) {
 };
 
 BTSyncAPI.prototype.addFolder = function (params, callback) {
+  _this = this;
+  var hasRetried = false;
+
   params = _.extend(params, {
     token: this.token
   }, false);
@@ -95,7 +98,19 @@ BTSyncAPI.prototype.addFolder = function (params, callback) {
     json: true,
     url: this.url + '/folders?' + querystring.stringify(params),
   }, function(err, res, body) {
-    return callback(err, body);
+    // try to reestablish connection only once
+    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+      _this.getTokenAndCookie(function(err, token) {
+        if(err) return callback(err); // we can not reconnect
+
+        hasRetried = true;
+
+        _this.setToken(token);
+        _this.addFolder(params, callback);
+      });
+    } else {
+      return callback(err, body);
+    }
   });
 };
 
@@ -113,6 +128,9 @@ BTSyncAPI.prototype.getInvitationLink = function (folderId, params, callback) {
 };
 
 BTSyncAPI.prototype.removeFolder = function (folderId, params, callback) {
+  _this = this;
+  var hasRetried = false;
+
   params = _.extend(params, {
     token: this.token
   }, false);
@@ -121,11 +139,26 @@ BTSyncAPI.prototype.removeFolder = function (folderId, params, callback) {
     json: true,
     url: this.url + '/folders/' + folderId + '?' + querystring.stringify(params),
   }, function(err, res, body) {
-    return callback(err, body);
+    // try to reestablish connection only once
+    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+      _this.getTokenAndCookie(function(err, token) {
+        if(err) return callback(err); // we can not reconnect
+
+        hasRetried = true;
+
+        _this.setToken(token);
+        _this.removeFolder(folderId, params, callback);
+      });
+    } else {
+      return callback(err, body);
+    }
   });
 };
 
 BTSyncAPI.prototype.generateSecret = function (params, callback) {
+  _this = this;
+  var hasRetried = false;
+
   params = _.extend(params, {
     token: this.token
   }, false);
@@ -134,7 +167,19 @@ BTSyncAPI.prototype.generateSecret = function (params, callback) {
     json: true,
     url: this.url + '/secret?' + querystring.stringify(params),
   }, function(err, res, body) {
-    return callback(err, body);
+    // try to reestablish connection only once
+    if (err && body !== '\r\ninvalid request' && !hasRetried) {
+      _this.getTokenAndCookie(function(err, token) {
+        if (err) return callback(err); // we can not reconnect
+
+        hasRetried = true;
+
+        _this.setToken(token);
+        _this.generateSecret(params, callback);
+      });
+    } else {
+      return callback(err, body);
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Ben Evans <ben@bensbit.co.uk> (http://bensbit.co.uk)",
   "license": "MIT",
   "dependencies": {
-    "request": "~2.29.0",
-    "underscore": "~1.5.1"
+    "request": "~2.67.0",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
@bencevans hey, first of all thanks for your work on this module

I've added a basic support of btsync api 2 so it works with the current btsync 2.2.7

I'm still planning to improve the code a bit and update the tests.

Just wanted to know if you are motivated to accept pull requests to support api v2 and continue updating the npm or would rather prefer me to submit the code as a new module. Just let me know.
